### PR TITLE
Hawkular-1295 Migrate Alerts to Prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 /config/environments/*.local.yml
 
 /spec/manageiq
+
+.idea/

--- a/app/models/manageiq/providers/hawkular/inventory/parser/availability_updates.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/availability_updates.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers
   class Hawkular::Inventory::Parser::AvailabilityUpdates < ManagerRefresh::Inventory::Parser
+    include Vmdb::Logging
+
     def parse
       fetch_server_availabilities
       fetch_deployment_availabilities
@@ -16,18 +18,21 @@ module ManageIQ::Providers
     end
 
     def fetch_server_availabilities
+      _log.info("DELETEME fetch_server_availabilities")
       find_updated_resource(:server) do |server, item|
         server.properties = item.options
       end
     end
 
     def fetch_deployment_availabilities
+      _log.info("DELETEME fetch_deployment_availabilities")
       find_updated_resource(:deployment) do |deployment, item|
         deployment.status = item.options[:status]
       end
     end
 
     def fetch_domain_availabilities
+      _log.info("DELETEME fetch_deployment_availabilities")
       find_updated_resource(:domain) do |domain, item|
         domain.properties = item.options
       end

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -54,7 +54,7 @@ module ManageIQ::Providers
       begin
         # As the connect will only give a handle
         # we verify the credentials via an actual operation
-        connect(options).inventory.list_feeds
+        connect(options).inventory.root_resources
       rescue URI::InvalidComponentError
         raise MiqException::MiqHostError, "Host '#{hostname}' is invalid"
       rescue ::Hawkular::ConnectionException
@@ -149,8 +149,8 @@ module ManageIQ::Providers
       end
     end
 
-    def metrics_client
-      with_provider_connection(&:metrics)
+    def prometheus_client
+      with_provider_connection(&:prometheus)
     end
 
     def inventory_client

--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
@@ -12,18 +12,18 @@ module ManageIQ::Providers
       group_conditions = convert_to_group_conditions(miq_alert)
 
       case operation
-      when :new
-        @alerts_client.create_group_trigger(group_trigger)
-        @alerts_client.set_group_conditions(group_trigger.id,
-                                            :FIRING,
-                                            group_conditions)
-      when :update
-        @alerts_client.update_group_trigger(group_trigger)
-        @alerts_client.set_group_conditions(group_trigger.id,
-                                            :FIRING,
-                                            group_conditions)
-      when :delete
-        @alerts_client.delete_group_trigger(group_trigger.id)
+        when :new
+          @alerts_client.create_group_trigger(group_trigger)
+          @alerts_client.set_group_conditions(group_trigger.id,
+                                              :FIRING,
+                                              group_conditions)
+        when :update
+          @alerts_client.update_group_trigger(group_trigger)
+          @alerts_client.set_group_conditions(group_trigger.id,
+                                              :FIRING,
+                                              group_conditions)
+        when :delete
+          @alerts_client.delete_group_trigger(group_trigger.id)
       end
     end
 
@@ -54,28 +54,19 @@ module ManageIQ::Providers
 
     def self.extract_alert_id(alert)
       case alert
-      when Hash
-        alert[:id]
-      when Numeric
-        alert
-      else
-        alert.id
+        when Hash
+          alert[:id]
+        when Numeric
+          alert
+        else
+          alert.id
       end
     end
+
     private_class_method :extract_alert_id
 
     def convert_to_group_trigger(operation, miq_alert)
       eval_method = miq_alert[:conditions][:eval_method]
-      firing_match = 'ALL'
-      # Storing prefixes for Hawkular Metrics integration
-      # These prefixes are used by alert_profile_manager.rb on member triggers creation
-      context = { 'dataId.hm.type' => 'gauge', 'dataId.hm.prefix' => 'hm_g_' }
-      case eval_method
-      when "mw_heap_used", "mw_non_heap_used"
-        firing_match = 'ANY'
-      when "mw_accumulated_gc_duration"
-        context = { 'dataId.hm.type' => 'counter', 'dataId.hm.prefix' => 'hm_c_' }
-      end
 
       trigger_id = if operation == :new
                      build_hawkular_trigger_id(miq_alert)
@@ -83,18 +74,102 @@ module ManageIQ::Providers
                      resolve_hawkular_trigger_id(miq_alert)
                    end
 
-      ::Hawkular::Alerts::Trigger.new('id'          => trigger_id,
-                                      'name'        => miq_alert[:description],
+      ::Hawkular::Alerts::Trigger.new('id' => trigger_id,
+                                      'name' => miq_alert[:description],
                                       'description' => miq_alert[:description],
-                                      'enabled'     => miq_alert[:enabled],
-                                      'type'        => :GROUP,
-                                      'eventType'   => :EVENT,
-                                      'firingMatch' => firing_match,
-                                      'context'     => context,
-                                      'tags'        => {
-                                        'miq.event_type'    => 'hawkular_alert',
-                                        'miq.resource_type' => miq_alert[:based_on]
+                                      'enabled' => miq_alert[:enabled],
+                                      'type' => :GROUP,
+                                      'eventType' => :EVENT,
+                                      'tags' => {
+                                          'miq.event_type' => 'hawkular_alert',
+                                          'miq.resource_type' => miq_alert[:based_on],
+                                          'prometheus' => 'unused_value'
                                       })
+    end
+
+    def convert_to_group_conditions(miq_alert)
+      eval_method = miq_alert[:conditions][:eval_method]
+      options = miq_alert[:conditions][:options]
+      case eval_method
+        when "mw_accumulated_gc_duration" then
+          generate_mw_gc_condition(eval_method, options)
+        when "mw_heap_used", "mw_non_heap_used" then
+          generate_mw_jvm_conditions(eval_method, options)
+        when *MW_DATASOURCE then
+          generate_mw_generic_threshold_conditions(options, mw_datasource_metrics_by_column[eval_method])
+        when *MW_MESSAGING then
+          generate_mw_generic_threshold_conditions(options, mw_messaging_topic_metrics_by_column[eval_method])
+        when *MW_WEB_SESSIONS then
+          generate_mw_generic_threshold_conditions(options, mw_server_metrics_by_column[eval_method])
+        when *MW_TRANSACTIONS then
+          generate_mw_generic_threshold_conditions(options, mw_server_metrics_by_column[eval_method])
+      end
+    end
+
+    def mw_server_metrics_by_column
+      MiddlewareServer.live_metrics_config['middleware_server']['supported_metrics_by_column']
+    end
+
+    def mw_datasource_metrics_by_column
+      MiddlewareDatasource.live_metrics_config['middleware_datasource']['supported_metrics_by_column']
+    end
+
+    def mw_messaging_topic_metrics_by_column
+      MiddlewareMessaging.live_metrics_config['middleware_messaging_jms_topic']['supported_metrics_by_column']
+    end
+
+    def generate_mw_gc_condition(eval_method, options)
+      c = ::Hawkular::Alerts::Trigger::Condition.new({})
+      c.trigger_mode = :FIRING
+      c.type = :EXTERNAL
+      c.alerter_id = 'prometheus'
+      c.data_id = 'group_data_id'
+
+      operator = options[:mw_operator]
+      # metrics is in seconds, so convert ms to s
+      threshold = options[:value_mw_garbage_collector].to_i / 1000.0
+      expression = 'sum(delta($FAMILY_TS(Accumulated GC Duration)[1m]))'
+      c.expression = "#{expression} #{operator} #{threshold}"
+
+      ::Hawkular::Alerts::Trigger::GroupConditionsInfo.new([c])
+    end
+
+    def generate_mw_jvm_conditions(eval_method, options)
+      c = ::Hawkular::Alerts::Trigger::Condition.new({})
+      c.trigger_mode = :FIRING
+      c.type = :EXTERNAL
+      c.alerter_id = 'prometheus'
+      c.data_id = 'group_data_id'
+
+      gt = options[:value_mw_greater_than].to_f / 100
+      lt = options[:value_mw_less_than].to_f / 100
+      expression = "$TS(Heap Used)/$TS(Heap Max)"
+      gt_expression = "(#{expression} > #{gt})"
+      lt_expression = "(#{expression} < #{lt})"
+      c.expression = "#{gt_expression} OR #{lt_expression}"
+      ::Hawkular::Alerts::Trigger::GroupConditionsInfo.new([c])
+    end
+
+    def generate_mw_generic_threshold_conditions(options, metric)
+      ::Hawkular::Alerts::Trigger::GroupConditionsInfo.new(
+          [
+              generate_mw_threshold_condition(
+                  metric,
+                  options[:mw_operator],
+                  options[:value_mw_threshold].to_i
+              )
+          ]
+      )
+    end
+
+    def generate_mw_threshold_condition(metric, operator, threshold)
+      c = ::Hawkular::Alerts::Trigger::Condition.new({})
+      c.trigger_mode = :FIRING
+      c.type = :EXTERNAL
+      c.alerter_id = 'prometheus'
+      c.data_id = 'group_data_id'
+      c.expression = "$TS(#{metric}) #{operator} #{threshold}"
+      c
     end
 
     MW_WEB_SESSIONS = %w(
@@ -131,92 +206,7 @@ module ManageIQ::Providers
       mw_tx_resource_rollbacks
       mw_tx_aborted
     ).freeze
-    def convert_to_group_conditions(miq_alert)
-      eval_method = miq_alert[:conditions][:eval_method]
-      options = miq_alert[:conditions][:options]
-      case eval_method
-      when "mw_accumulated_gc_duration"       then generate_mw_gc_condition(eval_method, options)
-      when "mw_heap_used", "mw_non_heap_used" then generate_mw_jvm_conditions(eval_method, options)
-      when *MW_DATASOURCE then generate_mw_generic_threshold_conditions(options, mw_datasource_metrics_by_column[eval_method])
-      when *MW_MESSAGING then generate_mw_generic_threshold_conditions(options, mw_messaging_topic_metrics_by_column[eval_method])
-      when *MW_WEB_SESSIONS,
-           *MW_TRANSACTIONS then generate_mw_generic_threshold_conditions(options, mw_server_metrics_by_column[eval_method])
-      end
-    end
-
-    def mw_server_metrics_by_column
-      MiddlewareServer.live_metrics_config['middleware_server']['supported_metrics_by_column']
-    end
-
-    def mw_datasource_metrics_by_column
-      MiddlewareDatasource.live_metrics_config['middleware_datasource']['supported_metrics_by_column']
-    end
-
-    def mw_messaging_topic_metrics_by_column
-      MiddlewareMessaging.live_metrics_config['middleware_messaging_jms_topic']['supported_metrics_by_column']
-    end
-
-    def generate_mw_gc_condition(eval_method, options)
-      c = ::Hawkular::Alerts::Trigger::Condition.new({})
-      c.trigger_mode = :FIRING
-      c.data_id = mw_server_metrics_by_column[eval_method]
-      c.type = :RATE
-      c.operator = convert_operator(options[:mw_operator])
-      c.threshold = options[:value_mw_garbage_collector].to_i
-      ::Hawkular::Alerts::Trigger::GroupConditionsInfo.new([c])
-    end
-
-    def generate_mw_jvm_conditions(eval_method, options)
-      data_id = mw_server_metrics_by_column[eval_method]
-      data2_id = if eval_method == "mw_heap_used" then mw_server_metrics_by_column["mw_heap_max"]
-                 else mw_server_metrics_by_column["mw_non_heap_committed"]
-                 end
-      c = []
-      c[0] = generate_mw_compare_condition(data_id, data2_id, :GT, options[:value_mw_greater_than].to_f / 100)
-      c[1] = generate_mw_compare_condition(data_id, data2_id, :LT, options[:value_mw_less_than].to_f / 100)
-      ::Hawkular::Alerts::Trigger::GroupConditionsInfo.new(c)
-    end
-
-    def generate_mw_compare_condition(data_id, data2_id, operator, data2_multiplier)
-      c = ::Hawkular::Alerts::Trigger::Condition.new({})
-      c.trigger_mode = :FIRING
-      c.data_id = data_id
-      c.data2_id = data2_id
-      c.type = :COMPARE
-      c.operator = operator
-      c.data2_multiplier = data2_multiplier
-      c
-    end
-
-    def generate_mw_threshold_condition(data_id, operator, threshold)
-      c = ::Hawkular::Alerts::Trigger::Condition.new({})
-      c.trigger_mode = :FIRING
-      c.data_id = data_id
-      c.type = :THRESHOLD
-      c.operator = operator
-      c.threshold = threshold
-      c
-    end
-
-    def generate_mw_generic_threshold_conditions(options, data_id)
-      ::Hawkular::Alerts::Trigger::GroupConditionsInfo.new(
-        [
-          generate_mw_threshold_condition(
-            data_id,
-            convert_operator(options[:mw_operator]),
-            options[:value_mw_threshold].to_i
-          )
-        ]
-      )
-    end
-
-    def convert_operator(op)
-      case op
-      when "<"       then :LT
-      when "<=", "=" then :LTE
-      when ">"       then :GT
-      when ">="      then :GTE
-      end
-    end
   end
+
 end
+

--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_profile_manager.rb
@@ -1,6 +1,7 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::AlertProfileManager
     require 'hawkular/hawkular_client'
+    require 'digest/sha1'
 
     def initialize(ems)
       @ems = ems
@@ -85,29 +86,34 @@ module ManageIQ::Providers
     end
 
     def create_new_member(group_trigger, member_id)
-      server = MiddlewareServer.find(member_id)
+      resource = MiddlewareServer.find(member_id)
+      create_new_member_from_resource(group_trigger, resource)
+    end
+
+    def create_new_member_from_resource(group_trigger, resource)
       new_member = ::Hawkular::Alerts::Trigger::GroupMemberInfo.new
       new_member.group_id = group_trigger.id
-      new_member.member_id = "#{group_trigger.id}-#{member_id}"
-      new_member.member_name = "#{group_trigger.name} for #{server.name}"
-      new_member.member_context = {'resource_path' => server.ems_ref.to_s}
-      new_member.data_id_map = calculate_member_data_id_map(server, group_trigger)
+      member_trigger_id = "#{group_trigger.id}-#{resource.id}"
+      new_member.member_id = member_trigger_id
+      new_member.member_name = "#{group_trigger.name} for #{resource.name}"
+      # Note, the dataId must be unique to the member trigger but can not be the member trigger id because
+      # that is not allowed by hAlerts (will cause infinite event chaining).  So, use a digest.
+      new_member.data_id_map = { 'group_data_id' => Digest::SHA1.hexdigest(member_trigger_id) }
+      new_member.member_context = calculate_member_context(resource, group_trigger.conditions[0].expression)
+
       @alerts_client.create_member_trigger(new_member)
     end
 
-    def calculate_member_data_id_map(server, group_trigger)
-      data_id_map = {}
-      prefix = group_trigger.context['dataId.hm.prefix'].nil? ? '' : group_trigger.context['dataId.hm.prefix']
-
-      group_trigger.conditions.each do |condition|
-        id_prefix = "#{prefix}MI~R~[#{server.feed}/#{server.nativeid}]~MT~"
-
-        data_id_map[condition.data_id] = "#{id_prefix}#{condition.data_id}"
-        unless condition.data2_id.nil?
-          data_id_map[condition.data2_id] = "#{id_prefix}#{condition.data2_id}"
-        end
+    def calculate_member_context(resource, expression)
+      context = {}
+      context['resource_path'] = resource.ems_ref.to_s
+      resource.metrics_available.each do |metric|
+        ts = "$TS(#{metric['displayName']})"
+        family_ts = "$FAMILY_TS(#{metric['displayName']})"
+        context[ts] = metric['expression'] if (expression.include?(ts))
+        context[family_ts] = metric['expression'].match("#{metric['family']}{.*}") if (expression.include?(family_ts))
       end
-      data_id_map
+      context
     end
 
     private

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
   def initialize(ems)
     @ems               = ems
     @alerts_client     = ems.alerts_client
-    @metrics_client    = ems.metrics_client
+    @prometheus_client = ems.prometheus_client
     @inventory_client  = ems.inventory_client
     @collecting_events = false
   end
@@ -127,9 +127,10 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
 
     # Get availabilities
     avails = {}
-    parser.fetch_availabilities_for(inventory_entities, entities, entities.first.class::AVAIL_TYPE_ID) do |item, avail|
-      avail_data = avail.try(:[], 'data').try(:first)
-      avails[item.id] = yield(item, avail_data)
+    parser.fetch_availabilities_for(inventory_entities,
+                                    entities,
+                                    entities.first.class::AVAIL_TYPE_ID) do |item, avail|
+      avails[item.id] = yield(item, avail)
 
       # Filter out if availability is unchanged. This way, no refresh is triggered if unnecessary.
       avails.delete(item.id) unless avails[item.id]

--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -1,127 +1,118 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::LiveMetricsCapture
+    include Vmdb::Logging
+
     class MetricValidationError < RuntimeError; end
+
+    ONE_HOUR = 60 * 60
+    ONE_DAY = 60 * 60 * 24
+    ONE_WEEK = ONE_DAY * 7
 
     def initialize(target)
       @target = target
       @ems = @target.ext_management_system
-      @metrics_client = @ems.metrics_client
-      @gauges = @metrics_client.gauges
-      @counters = @metrics_client.counters
-      @avail = @metrics_client.avail
+      @prometheus_client = @ems.prometheus_client
       @included_children = @target.included_children
       @supported_metrics = @target.supported_metrics
     end
 
     def fetch_metrics_available
+      _log.info("DELETEME fetch_metrics_available ⁻ BEGIN")
       resource = @included_children ? @ems.resource_tree(@target.ems_ref) : @ems.resource(@target.ems_ref)
       resource.metrics(!!@included_children)
-              .select { |m| @supported_metrics.key?(m.hawkular_type_id) }.collect do |metric|
-        parse_metric(metric)
-      end
-    end
-
-    def parse_metric(metric)
-      {:id => metric.hawkular_id, :name => @supported_metrics[metric.hawkular_type_id], :type => metric.hawkular_type, :unit => metric.unit}
-    end
-
-    def parse_metrics_ids(metrics)
-      gauge_ids = []
-      counter_ids = []
-      avail_ids = []
-      metrics_ids_map = {}
-      metrics.each do |metric|
-        metric_id = metric[:id]
-        case metric[:type]
-        when "GAUGE"        then gauge_ids.push(metric_id)
-        when "COUNTER"      then counter_ids.push(metric_id)
-        when "AVAILABILITY" then avail_ids.push(metric_id)
-        end
-        metrics_ids_map[metric_id] = metric[:name]
-      end
-      [gauge_ids, counter_ids, avail_ids, metrics_ids_map]
+              .select { |metric| @supported_metrics[@target.live_metrics_type].key?(metric.name) }
+              .collect do |metric|
+                metric_hash = metric.to_h
+                metric_hash['name'] = @supported_metrics[@target.live_metrics_type][metric.name]
+                metric_hash
+              end
+              .to_a
     end
 
     def collect_stats_metrics(metrics, start_time, end_time, interval)
-      return [{}, {}] if metrics.empty?
-      gauge_ids, counter_ids, avail_ids, metrics_ids_map = parse_metrics_ids(metrics)
-      starts = start_time.to_i.in_milliseconds
-      ends = (end_time + interval).to_i.in_milliseconds + 1
-      bucket_duration = "#{interval}s"
-      raw_stats = @metrics_client.query_stats(:gauge_ids       => gauge_ids,
-                                              :counter_ids     => counter_ids,
-                                              :avail_ids       => avail_ids,
-                                              :rates           => true,
-                                              :starts          => starts,
-                                              :ends            => ends,
-                                              :bucket_duration => bucket_duration)
-      [metrics_ids_map, raw_stats]
+      _log.info("DELETEME collect_stats_metrics metrics #{metrics} metrics.empty? #{metrics.empty?}")
+      return [] if metrics.empty?
+      starts = start_time.to_i
+      ends = (end_time + interval).to_i + 1
+      step = "#{interval}s"
+      results = @prometheus_client.query_range(:metrics => metrics,
+                                               :starts  => starts,
+                                               :ends    => ends,
+                                               :step    => step)
+      _log.info("DELETEME collect_stats_metrics results #{results}")
+      results
     end
 
     def collect_live_metrics(metrics, start_time, end_time, interval)
-      metrics_ids_map, raw_stats = collect_stats_metrics(metrics, start_time, end_time, interval)
-      process_stats(metrics_ids_map, raw_stats)
+      _log.info("DELETEME collect_live_metrics start_time #{start_time} end_time #{end_time} interval #{interval}")
+      raw_stats = collect_stats_metrics(metrics, start_time, end_time, interval)
+      process_stats(raw_stats)
     end
 
-    def process_stats(metrics_ids_map, raw_stats)
+    def collect_report_metrics(report_cols, start_time, end_time, interval)
+      _log.info("DELETEME collect_report_metrics start_time #{start_time} end_time #{end_time} interval #{interval}")
+      # TODO We might want to update this in the future as we don't have out of the box min/max/samples data but perhaps
+      # TODO it is not necessary now for these reports
+      # TODO In the future we might need support from inventory for customized reports
+      filtered = @target.metrics_available.select { |metric| report_cols.nil? || report_cols.include?(metric['name']) }
+      report_metrics = collect_live_metrics(filtered, start_time, end_time, interval)
+      _log.info("DELETEME collect_report_metrics report_metrics #{report_metrics}")
+      report_metrics
+    end
+
+    def process_stats(raw_stats)
+      _log.info("DELETEME process_stats raw_stats #{raw_stats}")
       processed = Hash.new { |h, k| h[k] = {} }
-      %w(availability gauge counter_rate).each do |type|
-        next unless raw_stats.key?(type)
-        raw_data = raw_stats[type]
-        raw_data.each do |metric_id, buckets|
-          metric_name = metrics_ids_map[metric_id]
-          norm_data = sort_and_normalize(buckets)
-          norm_data.each do |bucket|
-            timestamp = Time.at(bucket['start'] / 1.in_milliseconds).utc.to_i
-            value = type == 'availability' ? bucket['uptimeRatio'] : bucket['avg']
-            processed.store_path(timestamp, metric_name, value)
-          end
+      raw_stats.each do |raw_data|
+        next unless raw_data['values']
+        raw_data['values'].each do |datapoint|
+          timestamp = datapoint.first
+          value = datapoint.last.to_f
+          processed.store_path(timestamp, raw_data['metric']['name'], value)
         end
       end
+      _log.info("DELETEME process_stats processed #{processed}")
       processed
     end
 
-    def first_and_last_capture_for_metrics(metrics)
-      firsts, lasts = metrics.collect do |metric|
-        first_and_last_capture(metric)
-      end.transpose
-      [firsts, lasts]
-    end
-
-    def first_and_last_capture(metric)
-      validate_metric(metric)
-      case metric[:type]
-      when "GAUGE"        then min_max_timestamps(@gauges, metric[:id])
-      when "COUNTER"      then min_max_timestamps(@counters, metric[:id])
-      when "AVAILABILITY" then min_max_timestamps(@avail, metric[:id])
-      else raise MetricValidationError, "Validation error: unknown type #{metric_type}"
+    def first_and_last_capture(interval_name = "realtime")
+      _log.info("DELETEME first_and_last_capture #{interval_name}")
+      now = Time.new.utc
+      one_week_before = now - ONE_WEEK
+      last = now
+      first = now
+      results = @prometheus_client.up_time(:feed_id => @target.feed,
+                                           :starts  => one_week_before.to_i,
+                                           :ends    => now.to_i,
+                                           :step    => '3600m')
+      _log.info("DELETEME first_and_last_capture results #{results}")
+      if results.empty?
+        one_day_before = now - ONE_DAY
+        results = @prometheus_client.up_time(:feed_id => @target.feed,
+                                             :starts  => one_day_before.to_i,
+                                             :ends    => now.to_i,
+                                             :step    => '60m')
       end
-    end
-
-    def validate_metric(metric)
-      unless metric && %i(id name type unit).all? { |k| metric.key?(k) }
-        raise MetricValidationError, "Validation error: metric #{metric} must be defined"
+      unless results.empty?
+        datapoint = results.first
+        _log.info("DELETEME first_and_last_capture datapoint #{datapoint}")
+        first = Time.at(datapoint.first.to_i)
       end
+      if interval_name == "hourly"
+        first = (now - first) > 1.hour ? first : nil
+      end
+      _log.info("DELETEME first_and_last_capture [first, last] #{[first, last]}")
+      [first, last]
     end
+  end
 
-    def min_max_timestamps(client, metric_id)
-      metric_def = client.get(metric_id)
-      [metric_def.json['minTimestamp'], metric_def.json['maxTimestamp']]
-    end
-
-    def sort_and_normalize(data)
-      # Sorting and removing last entry because always incomplete
-      # as it's still in progress.
-      norm_data = (data.sort_by { |x| x['start'] }).slice(0..-2)
-      norm_data.reject { |x| x.values.include?('NaN') }
-    end
-
-    private
-
-    def extract_feed(ems_ref)
-      s_start = ems_ref.index("/f;") + 3
-      s_end = ems_ref.index("/", s_start) - 1
-      ems_ref[s_start..s_end]
+  module Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
+    def metrics_capture
+      @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)
+      _log.info("DELETEME metrics_capture self #{self}")
+      _log.info("DELETEME metrics_capture @metrics_capture #{@metrics_capture}")
+      _log.info("DELETEME metrics_capture @metrics_capture.methods #{@metrics_capture.methods}")
+      @metrics_capture
     end
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource.rb
@@ -1,4 +1,5 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareDatasource < MiddlewareDatasource
+    include ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_deployment.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_deployment.rb
@@ -4,6 +4,7 @@ module ManageIQ::Providers
     PARENT_DEPLOYMENT_ID_PROPERTY = 'Parent deployment id'.freeze
 
     def parent_deployment_id
+      ## TODO Check if this property is supported in inventory v4
       properties.try(:[], PARENT_DEPLOYMENT_ID_PROPERTY)
     end
 

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_messaging.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_messaging.rb
@@ -1,4 +1,30 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareMessaging < MiddlewareMessaging
+    include ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
+
+    def live_metrics_type
+      _log.info("DELETEME middleware_messaging -> live_metrics_type #{messaging_type}")
+      messaging_type
+    end
+
+    def chart_report_name
+      @chart_report_name ||= if messaging_type.start_with?('JMS Queue')
+                               "#{self.class.name.demodulize.underscore}_jms_queue"
+                             else
+                               "#{self.class.name.demodulize.underscore}_jms_topic"
+                             end
+      _log.info("DELETEME middleware_messaging chart_report_name #{@chart_report_name}")
+      @chart_report_name
+    end
+
+    def chart_layout_path
+      @chart_layout_path ||= if messaging_type.start_with?('JMS Queue')
+                               "#{self.class.name.demodulize}_jms_queue"
+                             else
+                               "#{self.class.name.demodulize}_jms_topic"
+                             end
+      _log.info("DELETEME middleware_messaging chart_layout_path #{@chart_layout_path}")
+      @chart_layout_path
+    end
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareServer < MiddlewareServer
+    include ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
+
     AVAIL_TYPE_ID = 'Server Availability'.freeze
 
     has_many :middleware_diagnostic_reports, :dependent => :destroy

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,7 +69,7 @@
   :worker_base:
     :event_catcher:
       :event_catcher_hawkular:
-        :poll: 10.seconds
+        :poll: 1.minute
       :event_catcher_hawkular_datawarehouse:
         :alertable_tenants: ['_system', '_ops']
         :poll: 1.minute

--- a/manageiq-providers-hawkular.gemspec
+++ b/manageiq-providers-hawkular.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "hawkular-client", "~> 5.0.0.pre1"
+  s.add_runtime_dependency "hawkular-client", "~> 4.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/alert_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/alert_manager_spec.rb
@@ -9,23 +9,14 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::AlertManager do
   end
   let(:subject) { described_class.new(stubbed_ems) }
 
-  it '#convert_operator' do
-    expect(subject.send(:convert_operator, "<")).to eq(:LT)
-    expect(subject.send(:convert_operator, "<=")).to eq(:LTE)
-    expect(subject.send(:convert_operator, ">=")).to eq(:GTE)
-    expect(subject.send(:convert_operator, "=")).to eq(:LTE)
-    expect(subject.send(:convert_operator, ">")).to eq(:GT)
-    expect(subject.send(:convert_operator, "wrong operator")).to eq(nil)
-  end
-
   it '#generate_mw_threshold_condition' do
-    c = subject.send(:generate_mw_threshold_condition, "1", :LT, 3)
+    c = subject.send(:generate_mw_threshold_condition, "Available Count", "<", 3)
     expect(c).to be_a_kind_of(Hawkular::Alerts::Trigger::Condition)
-    expect(c.data_id).to eq("1")
+    expect(c.data_id).to eq("group_data_id")
     expect(c.trigger_mode).to eq(:FIRING)
-    expect(c.type).to eq(:THRESHOLD)
-    expect(c.operator).to eq(:LT)
-    expect(c.threshold).to eq(3)
+    expect(c.alerter_id).to eq("prometheus")
+    expect(c.type).to eq(:EXTERNAL)
+    expect(c.expression).to eq("$TS(Available Count) < 3")
   end
 
   context "Test conditions" do
@@ -41,18 +32,6 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::AlertManager do
         },
         :based_on    => "MiddlewareServer"
       }
-    end
-
-    it '#convert_to_group_conditions MW GC' do
-      miq_alert_condition[:conditions][:eval_method] = "mw_accumulated_gc_duration"
-      miq_alert_condition[:conditions][:options][:mw_operator] = "<"
-      miq_alert_condition[:conditions][:options][:value_mw_garbage_collector] = 100
-      expect(subject).to receive(:generate_mw_gc_condition).with(
-        'mw_accumulated_gc_duration',
-        :mw_operator                => "<",
-        :value_mw_garbage_collector => 100
-      )
-      subject.send(:convert_to_group_conditions, miq_alert_condition)
     end
 
     it '#convert_to_group_conditions MW GC' do


### PR DESCRIPTION
Replace Group triggers using hMetrics-based built-in conditions with
Group Triggers using Prometheus Alerter external conditions.

This leverages the updated live-metrics config files.

@lucasponce This PR for the client depends on another PR for the client.  If you prefer not to merge these into your branch it is OK, I can wait and later add PRs against the master branches.  But, this at least allows me to work against your branch for staging, since some of the live-metrics work supports the alerts work.  If you do merge we can consolidate, which may be useful.